### PR TITLE
Fix XDG_RUNTIME_DIR for audio/video playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,13 @@ on the network.
 
 3. If you are not running a desktop session, use the framebuffer.  Either
    export these variables yourself or rely on `load_venv.sh` which sets them
-   when missing.  Also set `XDG_RUNTIME_DIR` if you see SDL errors:
+   when missing.  If you get SDL or audio errors about `XDG_RUNTIME_DIR`,
+   ensure it points to a user-owned directory:
    ```bash
    export SDL_VIDEODRIVER=fbcon
    export SDL_FBDEV=/dev/fb0
-   export XDG_RUNTIME_DIR=/tmp
+   export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+   [ -d "$XDG_RUNTIME_DIR" ] || export XDG_RUNTIME_DIR="/tmp/xdg-$(id -u)"
    ```
 4. Run the helper with sudo so it can access `/dev/fb0`, create a
    virtual environment, install Python dependencies and start the

--- a/load_venv.sh
+++ b/load_venv.sh
@@ -21,7 +21,12 @@ python -m pip install -r requirements.txt
 # Use the framebuffer if no desktop session is running
 export SDL_VIDEODRIVER=${SDL_VIDEODRIVER:-fbcon}
 export SDL_FBDEV=${SDL_FBDEV:-/dev/fb0}
-export XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-/tmp}
+uid=$(id -u)
+runtime_default="/run/user/$uid"
+if [ ! -d "$runtime_default" ]; then
+    runtime_default="/tmp/xdg-$uid"
+fi
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-$runtime_default}"
 
 [ -d "$XDG_RUNTIME_DIR" ] || mkdir -p "$XDG_RUNTIME_DIR"
 

--- a/player_remote.py
+++ b/player_remote.py
@@ -6,7 +6,9 @@ import os
 # Ensure Pygame can use the framebuffer when no desktop session is running
 os.environ.setdefault("SDL_VIDEODRIVER", "fbcon")
 os.environ.setdefault("SDL_FBDEV", "/dev/fb0")
-os.environ.setdefault("XDG_RUNTIME_DIR", "/tmp")
+uid = str(os.getuid())
+runtime_default = f"/run/user/{uid}" if os.path.isdir(f"/run/user/{uid}") else f"/tmp/xdg-{uid}"
+os.environ.setdefault("XDG_RUNTIME_DIR", runtime_default)
 
 import time
 import requests


### PR DESCRIPTION
## Summary
- fix virtual environment loader to select a user-owned XDG_RUNTIME_DIR
- default XDG_RUNTIME_DIR in `player_remote.py` similarly
- document a safer value for XDG_RUNTIME_DIR in the README

## Testing
- `python -m py_compile player_remote.py remote_server.py player.py clip_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_686c3e464a74832d823b1de181988d17